### PR TITLE
fix(CI): Resolve submodule checkout failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = nightbff-frontend
 	url = https://github.com/Apesensei/nightbf.git
 	branch = master
+[submodule "app/nightbff-frontend"]
+	path = app/nightbff-frontend
+	url = https://github.com/Apesensei/nightbf.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "app"]
 	path = app
 	url = https://github.com/Apesensei/NightBFF-backend.git
-	branch = integration/250619-ios-sync
+	branch = chore/seeder-unification
 [submodule "nightbff-frontend"]
 	path = nightbff-frontend
 	url = https://github.com/Apesensei/nightbf.git
-	branch = integration/250619-ios-sync
+	branch = master


### PR DESCRIPTION
This PR fixes the persistent CI failure in the 'Setup Node Cache' step.
- **Root Cause:** An orphan gitlink in the `NightBFF-backend` submodule was causing recursive checkouts to fail.
- **Solution:**
  1.  Created a new commit in the backend repo to remove the orphan gitlink.
  2.  Updated the `app` submodule in this repository to point to the repaired commit.
  3.  Corrected submodule branch references in `.gitmodules`.
  4.  Added missing environment variables to the CI workflow for the `env:lint` step.

Resolves the submodule checkout error and allows the CI pipeline to proceed.