### PR TITLE
feat(ci): add security audit job to integration pipeline

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -233,6 +233,35 @@ jobs:
         if: env.CI != 'true'
         run: bash scripts/ci/choose-pg-port.sh
 
+  security_audit:
+    name: 'Security Audit'
+    runs-on: ubuntu-latest
+    needs: unit_backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+          
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: npm ci --legacy-peer-deps --include=optional
+        
+      - name: Run security audit
+        working-directory: ./${{ env.BACKEND_PATH }}
+        run: |
+          echo "🔍 Running npm security audit..."
+          npm audit --audit-level=moderate
+          echo "✅ Security audit completed"
+
   unit_frontend:
     name: 'Unit Tests - Frontend'
     runs-on: ubuntu-latest
@@ -310,7 +339,7 @@ jobs:
   integration_tests:
     name: 'Integration & E2E Tests'
     runs-on: ubuntu-latest
-    needs: [unit_backend, unit_frontend, contract_backend]
+    needs: [unit_backend, unit_frontend, contract_backend, security_audit]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add security_audit job after unit_backend job
- Run npm audit --audit-level=moderate on backend dependencies
- Update integration_tests to depend on security_audit
- Ensures CI fails on high/critical vulnerabilities
- Part of Security Stabilization ticket implementation

## Summary

Describe the change.

## Type

- [ ] docs-only
- [ ] chore
- [ ] fix
- [ ] feat

## Checklist

- [ ] CI green
- [ ] No secrets committed
- [ ] Local runbook tested (if applicable)
- [ ] Docs updated (README/INDEX where needed)

## Risk

- [ ] low
- [ ] medium
- [ ] high
