### PR TITLE
chore(ci): add main branch to ci triggers

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -9,9 +9,9 @@ name: 'NightBFF Integration CI'
 
 on:
   push:
-    branches: ['integration/**']
+    branches: ['main', 'integration/**']
   pull_request:
-    branches: ['integration/**']
+    branches: ['main', 'integration/**']
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem
CI workflow only triggers on `integration/**` branches, not on `main` branch pushes or PRs. This means production-ready changes merged to main don't get CI verification.

## Solution
- Add `main` to both `push` and `pull_request` triggers
- Maintains existing `integration/**` branch triggers
- Enables CI verification for all main branch changes

## Impact
- CI will now run on main branch pushes
- CI will run on PRs targeting main branch
- Provides safety net for production deployments
- No breaking changes to existing workflow

## Safety Measures
- Backup created: `.github/workflows/integration-ci.yml.backup`
- Minimal change: Only 2 lines modified
- Preserves all existing functionality